### PR TITLE
use configure_app and restructure FastAPI deps injection (GDEV-395)

### DIFF
--- a/metadata_search_service/api/deps.py
+++ b/metadata_search_service/api/deps.py
@@ -13,19 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Entrypoint of the package"""
+"""FastAPI dependencies (used with the `Depends` feature)"""
 
-from ghga_service_chassis_lib.api import run_server
-
-from .api.main import app  # noqa: F401 pylint: disable=unused-import
-from .config import CONFIG, Config
+from metadata_search_service.config import CONFIG
 
 
-def run(config: Config = CONFIG):
-    """Run the service"""
-    # Please adapt to package name
-    run_server(app="metadata_search_service.__main__:app", config=config)
-
-
-if __name__ == "__main__":
-    run()
+def get_config():
+    """Get runtime configuration."""
+    return CONFIG

--- a/metadata_search_service/api/main.py
+++ b/metadata_search_service/api/main.py
@@ -20,14 +20,17 @@ Additional endpoints might be structured in dedicated modules
 """
 
 from fastapi import Depends, FastAPI, HTTPException
+from ghga_service_chassis_lib.api import configure_app
 
-from metadata_search_service.config import Config, get_config
+from metadata_search_service.api.deps import get_config
+from metadata_search_service.config import CONFIG, Config
 from metadata_search_service.dao.document import get_documents
 from metadata_search_service.models import DocumentType, SearchQuery, SearchResult
 
 # pylint: disable=too-many-arguments
 
 app = FastAPI()
+configure_app(app, config=CONFIG)
 
 
 @app.get("/", summary="Index for Metadata Search Service")

--- a/metadata_search_service/config.py
+++ b/metadata_search_service/config.py
@@ -31,5 +31,7 @@ class Config(ApiConfigBase, PubSubConfigBase):
     db_url: str = "mongodb://localhost:27017"
     db_name: str = "metadata-store"
 
+    service_name: str = "metadata-search-service"
+
 
 CONFIG = Config()

--- a/metadata_search_service/config.py
+++ b/metadata_search_service/config.py
@@ -15,8 +15,6 @@
 
 """Config Parameter Modeling and Parsing"""
 
-from functools import lru_cache
-
 from ghga_service_chassis_lib.api import ApiConfigBase
 from ghga_service_chassis_lib.config import config_from_yaml
 from ghga_service_chassis_lib.pubsub import PubSubConfigBase
@@ -34,7 +32,4 @@ class Config(ApiConfigBase, PubSubConfigBase):
     db_name: str = "metadata-store"
 
 
-@lru_cache
-def get_config():
-    """Get runtime configuration."""
-    return Config()
+CONFIG = Config()

--- a/metadata_search_service/config.py
+++ b/metadata_search_service/config.py
@@ -17,11 +17,10 @@
 
 from ghga_service_chassis_lib.api import ApiConfigBase
 from ghga_service_chassis_lib.config import config_from_yaml
-from ghga_service_chassis_lib.pubsub import PubSubConfigBase
 
 
 @config_from_yaml(prefix="metadata_search_service")
-class Config(ApiConfigBase, PubSubConfigBase):
+class Config(ApiConfigBase):
     """Config parameters and their defaults."""
 
     # config parameter needed for the api server
@@ -30,8 +29,6 @@ class Config(ApiConfigBase, PubSubConfigBase):
     # are inherited from PubSubConfigBase;
     db_url: str = "mongodb://localhost:27017"
     db_name: str = "metadata-store"
-
-    service_name: str = "metadata-search-service"
 
 
 CONFIG = Config()

--- a/metadata_search_service/dao/db.py
+++ b/metadata_search_service/dao/db.py
@@ -17,10 +17,10 @@
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from metadata_search_service.config import Config, get_config
+from metadata_search_service.config import CONFIG, Config
 
 
-async def get_db_client(config: Config = get_config()) -> AsyncIOMotorClient:
+async def get_db_client(config: Config = CONFIG) -> AsyncIOMotorClient:
     """
     Get database client.
     """

--- a/metadata_search_service/dao/document.py
+++ b/metadata_search_service/dao/document.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Set, Tuple
 import stringcase
 from pymongo import ASCENDING
 
-from metadata_search_service.config import Config, get_config
+from metadata_search_service.config import CONFIG, Config
 from metadata_search_service.core.utils import DEFAULT_FACET_FIELDS
 from metadata_search_service.dao.db import get_db_client
 
@@ -35,7 +35,7 @@ async def get_documents(
     return_facets: bool = False,
     skip: int = 0,
     limit: int = 10,
-    config: Config = get_config(),
+    config: Config = CONFIG,
 ) -> Tuple[List, List]:
     """
     Get documents for a given document type.
@@ -70,7 +70,7 @@ async def get_documents(
 
 
 async def _get_documents(
-    collection_name: str, skip: int = 0, limit: int = 10, config: Config = get_config()
+    collection_name: str, skip: int = 0, limit: int = 10, config: Config = CONFIG
 ):
     """
     Get documents from a given ``collection_name``.
@@ -96,7 +96,7 @@ async def _get_documents(
 
 @lru_cache()
 async def _get_reference(
-    document_id: str, collection_name: str, config: Config = get_config()
+    document_id: str, collection_name: str, config: Config = CONFIG
 ) -> Dict:
     """
     Given a document ID and a collection name, query the metadata store

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ console_scripts =
 # Please adapt:
 dev =
     ghga-service-chassis-lib[dev]==0.8.0
+    nest-asyncio
     typer
 all =
     %(dev)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,8 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    # Please adapt to the current version of the library
-    ghga-service-chassis-lib[pubsub,api]==0.4.0
+    ghga-service-chassis-lib[pubsub,api,mongo_connect]==0.8.0
     PyYAML==5.4.1
-    motor==2.5.1
     stringcase==1.2.0
 python_requires = >= 3.9
 
@@ -51,23 +49,8 @@ console_scripts =
 [options.extras_require]
 # Please adapt:
 dev =
-    pytest
-    pytest-cov
-    mypy
-    pylint
-    black
-    isort
-    bandit
-    flake8
-    pre-commit
-    requests
-    mkdocs
-    mkdocs-material
-    mkdocstrings
-    testcontainers
+    ghga-service-chassis-lib[dev]==0.8.0
     typer
-    nest_asyncio
-    pytest-asyncio
 all =
     %(dev)s
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    ghga-service-chassis-lib[pubsub,api,mongo_connect]==0.8.0
+    ghga-service-chassis-lib[api,mongo_connect]==0.8.0
     PyYAML==5.4.1
     stringcase==1.2.0
 python_requires = >= 3.9

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -20,8 +20,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from metadata_search_service.api.deps import get_config
 from metadata_search_service.api.main import app
-from metadata_search_service.config import Config, get_config
+from metadata_search_service.config import Config
 from tests.fixtures import initialize_test_db  # noqa: F401,F811
 
 nest_asyncio.apply()


### PR DESCRIPTION
Title for squash and merge:
```
use configure_app and restructure FastAPI deps injection (GDEV-395)
```

Description for squash and merge:
```
- use configure_app util from the ghga_service_chassis_lib to correctly configure CORS and more
- restructure default config management:
  - The default config is now available directly in the `CONFIG` variable
  - The `get_config` is moved to `api/deps.py` an should only be used for the FastAPI `Depends` feature
- Fixed python dependencies
```