### PR TITLE
Remove incompatible caching of async methods

### DIFF
--- a/metadata_search_service/dao/document.py
+++ b/metadata_search_service/dao/document.py
@@ -94,7 +94,6 @@ async def _get_documents(
     return docs
 
 
-@lru_cache()
 async def _get_reference(
     document_id: str, collection_name: str, config: Config = CONFIG
 ) -> Dict:

--- a/metadata_search_service/dao/document.py
+++ b/metadata_search_service/dao/document.py
@@ -15,7 +15,6 @@
 """DAO for retrieving a document from the metadata store"""
 
 import logging
-from functools import lru_cache
 from typing import Any, Dict, List, Set, Tuple
 
 import stringcase


### PR DESCRIPTION
Fixes bug introduced when trying to cache an async method.

Bug reported by @ac-jorellanaf 

Title for squash and merge:
```
Remove incompatible caching of async method
```

Description for squash and merge:
```
- Remove incompatible caching of async '_get_reference' method
```