### PR TITLE
Add counts to search result

### DIFF
--- a/metadata_search_service/api/main.py
+++ b/metadata_search_service/api/main.py
@@ -63,7 +63,7 @@ async def search(
             status_code=400,
             detail="'limit' parameter must be greater than or equal to 1",
         )
-    hits, facets = await perform_search(
+    hits, facets, count = await perform_search(
         document_type=document_type,
         search_query=query.query,
         filters=query.filters,
@@ -72,5 +72,5 @@ async def search(
         limit=limit,
         config=config,
     )
-    response = {"facets": facets, "hits": hits}
+    response = {"facets": facets, "count": count, "hits": hits}
     return response

--- a/metadata_search_service/core/search.py
+++ b/metadata_search_service/core/search.py
@@ -32,7 +32,7 @@ async def perform_search(
     skip: int = 0,
     limit: int = 10,
     config: Config = CONFIG,
-) -> Tuple[List[Dict], List[Dict]]:
+) -> Tuple[List[Dict], List[Dict], int]:
     """
     Perform a search on the metadata store and get all
     documents that match a given search query.
@@ -46,10 +46,11 @@ async def perform_search(
         config: The config
 
     Returns:
-        A list of documents with facets and a list of facets, if ``return_facets=True``
+        A list of documents, a list of facets (if ``return_facets=True``),
+        and a count representing total number of hits
 
     """
-    docs, facet_results = await get_documents(
+    docs, facet_results, count = await get_documents(
         collection_name=document_type,
         search_query=search_query,
         filters=filters,
@@ -78,4 +79,4 @@ async def perform_search(
                     }
                     facet["options"].append(facet_option)
                 facets.append(facet)
-    return hits, facets
+    return hits, facets, count

--- a/metadata_search_service/models.py
+++ b/metadata_search_service/models.py
@@ -18,7 +18,7 @@
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class DocumentType(str, Enum):
@@ -40,8 +40,11 @@ class FacetOption(BaseModel):
     Represent values and their corresponding count for a facet.
     """
 
-    option: str
-    count: Optional[int] = None
+    option: str = Field(description="One of the values for the facet")
+    count: Optional[int] = Field(
+        None,
+        description="The count that represents number of documents that has this facet value",
+    )
 
 
 class Facet(BaseModel):
@@ -49,8 +52,10 @@ class Facet(BaseModel):
     Represents a facet and the possible values for that facet.
     """
 
-    key: str
-    options: List[FacetOption]
+    key: str = Field(description="The facet key")
+    options: List[FacetOption] = Field(
+        description="One or more values and their counts"
+    )
 
 
 class FilterOption(BaseModel):
@@ -58,8 +63,8 @@ class FilterOption(BaseModel):
     Represents a Filter option.
     """
 
-    key: str
-    value: str
+    key: str = Field(description="The filter key")
+    value: str = Field(description="The filter value")
 
 
 class SearchQuery(BaseModel):
@@ -67,8 +72,10 @@ class SearchQuery(BaseModel):
     Represents the Search Query.
     """
 
-    query: str
-    filters: Optional[List[FilterOption]] = None
+    query: str = Field(description="The query string to use for search")
+    filters: Optional[List[FilterOption]] = Field(
+        None, description="One or more filters to apply when performing a search"
+    )
 
 
 class SearchHit(BaseModel):
@@ -76,10 +83,14 @@ class SearchHit(BaseModel):
     Represents the Search Hit.
     """
 
-    document_type: DocumentType
-    id: str
-    context: Optional[str] = None
-    content: Optional[Dict] = None
+    document_type: DocumentType = Field(description="The type of document")
+    id: str = Field(description="The unique identifier of the document")
+    context: Optional[str] = Field(
+        None, description="The context where this search hit was found"
+    )
+    content: Optional[Dict] = Field(
+        None, description="The full document of the search hit"
+    )
 
 
 class SearchResult(BaseModel):
@@ -87,5 +98,8 @@ class SearchResult(BaseModel):
     Represents the Search Result.
     """
 
-    facets: List[Facet]
-    hits: List[SearchHit]
+    facets: List[Facet] = Field(
+        description="One or more facets that summarizes the hits"
+    )
+    count: int = Field(description="Number of hits")
+    hits: List[SearchHit] = Field(description="One or more search hits")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,9 +17,11 @@ components:
       description: Represents a facet and the possible values for that facet.
       properties:
         key:
+          description: The facet key
           title: Key
           type: string
         options:
+          description: One or more values and their counts
           items:
             $ref: '#/components/schemas/FacetOption'
           title: Options
@@ -33,9 +35,12 @@ components:
       description: Represent values and their corresponding count for a facet.
       properties:
         count:
+          description: The count that represents number of documents that has this
+            facet value
           title: Count
           type: integer
         option:
+          description: One of the values for the facet
           title: Option
           type: string
       required:
@@ -46,9 +51,11 @@ components:
       description: Represents a Filter option.
       properties:
         key:
+          description: The filter key
           title: Key
           type: string
         value:
+          description: The filter value
           title: Value
           type: string
       required:
@@ -69,14 +76,19 @@ components:
       description: Represents the Search Hit.
       properties:
         content:
+          description: The full document of the search hit
           title: Content
           type: object
         context:
+          description: The context where this search hit was found
           title: Context
           type: string
         document_type:
-          $ref: '#/components/schemas/DocumentType'
+          allOf:
+          - $ref: '#/components/schemas/DocumentType'
+          description: The type of document
         id:
+          description: The unique identifier of the document
           title: Id
           type: string
       required:
@@ -88,11 +100,13 @@ components:
       description: Represents the Search Query.
       properties:
         filters:
+          description: One or more filters to apply when performing a search
           items:
             $ref: '#/components/schemas/FilterOption'
           title: Filters
           type: array
         query:
+          description: The query string to use for search
           title: Query
           type: string
       required:
@@ -102,18 +116,25 @@ components:
     SearchResult:
       description: Represents the Search Result.
       properties:
+        count:
+          description: Number of hits
+          title: Count
+          type: integer
         facets:
+          description: One or more facets that summarizes the hits
           items:
             $ref: '#/components/schemas/Facet'
           title: Facets
           type: array
         hits:
+          description: One or more search hits
           items:
             $ref: '#/components/schemas/SearchHit'
           title: Hits
           type: array
       required:
       - facets
+      - count
       - hits
       title: SearchResult
       type: object

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -62,6 +62,7 @@ def test_index():
                         "Whole genome bisufite sequencing for smoking and non-smoking mother-child pairs",
                     ]
                 },
+                "count": 5,
                 "facets": {},
             },
         ),
@@ -78,6 +79,7 @@ def test_index():
                         "Whole genome bisufite sequencing for smoking and non-smoking mother-child pairs",
                     ]
                 },
+                "count": 5,
                 "facets": {
                     "type": {
                         "sample": 1,
@@ -100,6 +102,7 @@ def test_index():
                         "DATA_SET_Coverage_bias_sensitivity_of_variant_calling_for_4_WG_seq_tech"
                     ]
                 },
+                "count": 5,
                 "facets": {
                     "type": {
                         "sample": 1,
@@ -123,6 +126,7 @@ def test_index():
                         "Epigenomic alterations define lethal CIMP-positive ependymomas of infancy",
                     ]
                 },
+                "count": 5,
                 "facets": {
                     "type": {"Other": 3, "Whole Genome Sequencing": 1, "Epigenetics": 1}
                 },
@@ -141,6 +145,7 @@ def test_index():
                         "Schwannomatosis WES data",
                     ]
                 },
+                "count": 2,
                 "facets": {"type": {"Exome sequencing": 2}},
             },
         ),
@@ -158,6 +163,7 @@ def test_index():
             10,
             {
                 "data": {"title": ["Schwannomatosis WES data"]},
+                "count": 1,
                 "facets": {"type": {"Exome sequencing": 1}},
             },
         ),
@@ -173,13 +179,14 @@ def test_index():
                         "Exome sequencing of serially transplanted genetically marked IC-enriched primary PDAC cultures.",
                     ]
                 },
+                "count": 1,
                 "facets": {"type": {"Exome sequencing": 1}},
             },
         ),
     ],
 )
 @pytest.mark.asyncio
-async def test_search(
+async def test_search(  # noqa: C901
     initialize_test_db,  # noqa: F811
     query,
     document_type,
@@ -205,6 +212,9 @@ async def test_search(
                 if i >= len(conditions["data"][key]):
                     break
                 assert doc[key] == conditions["data"][key][i]
+
+    if conditions["count"]:
+        assert data["count"] == conditions["count"]
 
     if return_facets:
         assert len(data["facets"]) > 0


### PR DESCRIPTION
Title for squash and merge:
```
Add counts to search result that represent total number hits
```

Description for squash and merge:
```
- Extend models
- Add total number of hits as part of the search response via 'count' field
- Add tests
```